### PR TITLE
Provide Helm chart to deploy gateway

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -39,11 +39,10 @@ stages:
        displayName: 'Change Build Number to PR format'
        condition: eq(variables['Build.Reason'], 'PullRequest')
      - powershell: |
-        helm lint $(Helm.Chart.Name)/ --strict
-       workingDirectory: charts
-       displayName: 'Lint Helm Chart'
-     - powershell: |
         copy LICENSE charts/$(Helm.Chart.Name)/
+       displayName: 'Copy License to Helm Chart'
+     - powershell: |
+        helm lint $(Helm.Chart.Name)/ --strict
        workingDirectory: charts
        displayName: 'Lint Helm Chart'
      - powershell: |

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -43,6 +43,10 @@ stages:
        workingDirectory: charts
        displayName: 'Lint Helm Chart'
      - powershell: |
+        copy LICENSE charts/$(Helm.Chart.Name)/
+       workingDirectory: charts
+       displayName: 'Lint Helm Chart'
+     - powershell: |
         echo 'Copying Chart folder'
         cp $(Helm.Chart.Name)/ $(Helm.Chart.CI.Name)/ -r
 

--- a/charts/azure-api-management-gateway/README.md
+++ b/charts/azure-api-management-gateway/README.md
@@ -1,0 +1,74 @@
+# Azure API Management Gateway
+
+[Self-hosted Azure API Management gateway](https://docs.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview) allows you to run Azure API Management gateway anywhere - Any cloud, hybrid or on-premises.
+
+## TL;DR
+
+```console
+helm repo add tomkerkhove https://tomkerkhove.azurecr.io/helm/v1/repo
+helm install tomkerkhove/azure-api-management-gateway
+```
+
+## Introduction
+
+This chart bootstraps an **Azure API Management gateway** deployment on a Kubernetes cluster using the Helm package manager.
+
+It will automatically federate itself with the configured Azure API Management instance and be ready to be consumed.
+
+## Prerequisites
+
+- Azure Subscription
+- Azure API Management instance which supports self-hosted gateways
+
+## Installing the Chart
+
+To install the chart with the release name `azure-api-management-gateway`:
+
+```console
+$ helm install --name azure-api-management-gateway tomkerkhove/azure-api-management-gateway \
+               --set gateway.endpoint='<gateway-url>' \
+               --set gateway.authKey='<gateway-key>'
+```
+
+The command deploys the [Azure API Management gateway](https://docs.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview) on the Kubernetes cluster.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `azure-api-management-gateway` deployment:
+
+```console
+helm delete azure-api-management-gateway
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Promitor chart and
+their default values.
+
+| Parameter                  | Description              | Default              |
+|:---------------------------|:-------------------------|:---------------------|
+| `image.repository`  | Repository which provides the image | `mcr.microsoft.com/azure-api-management/gateway` |
+| `image.tag`  | Tag of image to use | `beta`            |
+| `image.pullPolicy`  | Policy to pull image | `Always`            |
+| `resources`  | Pod resource requests & limits |    `{}`    |
+| `gateway.endpoint`  | Endpoint in Azure API Management to which every self-hosted agent has to connect | ``            |
+| `gateway.authKey`  | Authentication key to authenticate with to Azure API Management service. Typically starts with `GatewayKey ` | ``            |
+| `service.port`  | Port on service for other pods to talk to | `88`            |
+| `service.targetPort`  | Port on container to serve traffic | `8080`            |
+| `ingress.enabled`  | Indication wheter or not an ingress should be created | `false`            |
+| `ingress.annotations`  | Collection of annotations to assign to the ingress | None            |
+| `ingress.hosts`  | Host to expose ingress on |             |
+| `ingress.tls`  | Configuration for TLS on the ingress | None            |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can
+be provided while installing the chart. For example,
+
+```console
+helm install tomkerkhove/azure-api-management-gateway --name azure-api-management-gateway -f values.yaml
+```

--- a/charts/azure-api-management-gateway/README.md
+++ b/charts/azure-api-management-gateway/README.md
@@ -18,7 +18,8 @@ It will automatically federate itself with the configured Azure API Management i
 ## Prerequisites
 
 - Azure Subscription
-- Azure API Management instance which supports self-hosted gateways
+- Azure API Management instance
+    - A provisioned [self-hosted gateway](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-provision-self-hosted-gateway)
 
 ## Installing the Chart
 

--- a/charts/azure-api-management-gateway/README.md
+++ b/charts/azure-api-management-gateway/README.md
@@ -20,6 +20,7 @@ It will automatically federate itself with the configured Azure API Management i
 - Azure Subscription
 - Azure API Management instance
     - A provisioned [self-hosted gateway](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-provision-self-hosted-gateway)
+    - Endpoint & authentication information required for deployment. See `Deployment` section in Azure Portal for created local gateway
 
 ## Installing the Chart
 

--- a/charts/azure-api-management-gateway/templates/configmap.yaml
+++ b/charts/azure-api-management-gateway/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: ConfigMap
+metadata:
+  name: {{ include "azure-api-management-gateway.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "azure-api-management-gateway.name" . }}
+    helm.sh/chart: {{ include "azure-api-management-gateway.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.service.endpoint: {{ .Values.gateway.endpoint | quote }}

--- a/charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/charts/azure-api-management-gateway/templates/deployment.yaml
@@ -25,16 +25,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
+              containerPort: 8080
+            - name: https
+              containerPort: 8081
+          env:
+          - name: config.service.auth
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "azure-api-management-gateway.fullname" . }}
+                key: gateway-key
+          envFrom:
+          - configMapRef:
+              name: {{ include "azure-api-management-gateway.fullname" . }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/azure-api-management-gateway/templates/secret.yaml
+++ b/charts/azure-api-management-gateway/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: {{ include "azure-api-management-gateway.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "azure-api-management-gateway.name" . }}
+    helm.sh/chart: {{ include "azure-api-management-gateway.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  gateway-key: {{ .Values.gateway.authKey | b64enc | quote }}

--- a/charts/azure-api-management-gateway/values.yaml
+++ b/charts/azure-api-management-gateway/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: nginx
-  tag: stable
+  repository: mcr.microsoft.com/azure-api-management/gateway
+  tag: beta
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -14,7 +14,11 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
-  port: 80
+  port: 88
+
+gateway:
+  endpoint: 
+  authKey: 
 
 ingress:
   enabled: false

--- a/charts/azure-api-management-gateway/values.yaml
+++ b/charts/azure-api-management-gateway/values.yaml
@@ -17,8 +17,8 @@ service:
   port: 88
 
 gateway:
-  endpoint: 
-  authKey: 
+  endpoint: ""
+  authKey: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
Provide Helm chart to deploy gateway on Kubernetes.

Remaining work:
- [x] Verify chart locally
- [x] Document how to get the gateway info in Helm README

Closes #1, closes #3